### PR TITLE
r1.0.4

### DIFF
--- a/src/main/java/fr/nocsy/almpet/data/Items.java
+++ b/src/main/java/fr/nocsy/almpet/data/Items.java
@@ -109,7 +109,7 @@ public enum Items {
         lore.addAll(Arrays.asList(Language.NICKNAME_ITEM_LORE.getMessage().split("\n")));
 
         meta.setLore(lore);
-
+        meta.setLocalizedName(null);
         it.setItemMeta(meta);
         return it;
     }

--- a/src/main/java/fr/nocsy/almpet/data/PetDespawnReason.java
+++ b/src/main/java/fr/nocsy/almpet/data/PetDespawnReason.java
@@ -14,6 +14,7 @@ public enum PetDespawnReason {
     GAMEMODE("gamemode"),
     MYTHICMOBS("mythicmobs"),
     SPAWN_ISSUE("spawn issue"),
+    LOOP_SPAWN("loop spawn"),
     UNKNOWN("unkown");
 
 

--- a/src/main/java/fr/nocsy/almpet/data/config/GlobalConfig.java
+++ b/src/main/java/fr/nocsy/almpet/data/config/GlobalConfig.java
@@ -1,7 +1,9 @@
 package fr.nocsy.almpet.data.config;
 
+import fr.nocsy.almpet.AdvancedPet;
 import lombok.Getter;
 import lombok.Setter;
+import org.bukkit.Bukkit;
 
 public class GlobalConfig extends AbstractConfig {
 

--- a/src/main/java/fr/nocsy/almpet/data/config/Language.java
+++ b/src/main/java/fr/nocsy/almpet/data/config/Language.java
@@ -46,9 +46,12 @@ public enum Language {
     NO_ACTIVE_PET("§cYou have no active pet."),
     SIGNAL_STICK_GIVEN("§aYou've received an order stick. Right click to cast an order, left click to switch orders."),
     SIGNAL_STICK_SIGNAL("§6Active order : §e%signal%"),
+    LOOP_SPAWN("§cYour pet was revoked because it seems to struggle with numerous teleportations."),
 
     RELOAD_SUCCESS("§aReloaded successfully."),
     HOW_MANY_PETS_LOADED("§a%numberofpets% were registered successfully"),
+
+    REQUIRES_MODELENGINE("§cThis plugin requires ModelEngine r2.2.0. It seems that this requirement is not satisfied."),
 
     USAGE("§7Usage : §6/advancedpet §8..." +
                                         "\n§8   ... §areload " +

--- a/src/main/java/fr/nocsy/almpet/data/inventories/PetInteractionMenu.java
+++ b/src/main/java/fr/nocsy/almpet/data/inventories/PetInteractionMenu.java
@@ -32,6 +32,7 @@ public class PetInteractionMenu {
             inventory.setItem(1, Items.RENAME.getItem());
         else
             inventory.setItem(1, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
+
         inventory.setItem(2, Items.petInfo(pet));
 
         if(GlobalConfig.getInstance().isMountable() && pet.isMountable()) {

--- a/src/main/java/fr/nocsy/almpet/mythicmobs/MythicListener.java
+++ b/src/main/java/fr/nocsy/almpet/mythicmobs/MythicListener.java
@@ -1,9 +1,14 @@
 package fr.nocsy.almpet.mythicmobs;
 
+import fr.nocsy.almpet.AdvancedPet;
+import fr.nocsy.almpet.mythicmobs.mechanics.GivePetMechanic;
 import fr.nocsy.almpet.mythicmobs.targeters.TargeterPetOwner;
+import io.lumine.xikage.mythicmobs.api.bukkit.events.MythicMechanicLoadEvent;
 import io.lumine.xikage.mythicmobs.api.bukkit.events.MythicTargeterLoadEvent;
+import io.lumine.xikage.mythicmobs.skills.SkillMechanic;
 import io.lumine.xikage.mythicmobs.skills.SkillTargeter;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 public class MythicListener implements Listener {
@@ -17,6 +22,17 @@ public class MythicListener implements Listener {
             paramMythicTargeterLoadEvent.register((SkillTargeter) new TargeterPetOwner(paramMythicTargeterLoadEvent.getConfig()));
         }
 
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onMythicMechanicLoad(MythicMechanicLoadEvent event) {
+        if (event.getMechanicName().equalsIgnoreCase("GivePet")) {
+            GivePetMechanic givePetMechanic = new GivePetMechanic(event.getConfig());
+            event.register((SkillMechanic) givePetMechanic);
+
+            AdvancedPet.getLog().info("[AdvancedPet] : GivePet Mechanic loaded successfully");
+
+        }
     }
 
 }

--- a/src/main/java/fr/nocsy/almpet/mythicmobs/mechanics/GivePetMechanic.java
+++ b/src/main/java/fr/nocsy/almpet/mythicmobs/mechanics/GivePetMechanic.java
@@ -1,0 +1,35 @@
+package fr.nocsy.almpet.mythicmobs.mechanics;
+
+import fr.nocsy.almpet.AdvancedPet;
+import fr.nocsy.almpet.data.Pet;
+import io.lumine.xikage.mythicmobs.adapters.AbstractEntity;
+import io.lumine.xikage.mythicmobs.adapters.bukkit.BukkitAdapter;
+import io.lumine.xikage.mythicmobs.io.MythicLineConfig;
+import io.lumine.xikage.mythicmobs.skills.ITargetedEntitySkill;
+import io.lumine.xikage.mythicmobs.skills.SkillMechanic;
+import io.lumine.xikage.mythicmobs.skills.SkillMetadata;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+public class GivePetMechanic extends SkillMechanic implements ITargetedEntitySkill {
+
+    String petId;
+
+    public GivePetMechanic(MythicLineConfig config) {
+        super(config.getLine(), config);
+        setAsyncSafe(false);
+        this.petId = config.getString(new String[] { "id" }, this.petId);
+    }
+
+    public boolean castAtEntity(SkillMetadata data, AbstractEntity target) {
+        Entity player = BukkitAdapter.adapt(target);
+        if (player instanceof Player) {
+
+            Pet pet = Pet.getFromId(petId);
+            if(pet == null)
+                return false;
+            player.addAttachment(AdvancedPet.getInstance(), pet.getPermission(), true);
+        }
+        return true;
+    }
+}

--- a/src/main/java/fr/nocsy/almpet/utils/VolatileAIHandler.java
+++ b/src/main/java/fr/nocsy/almpet/utils/VolatileAIHandler.java
@@ -1,0 +1,33 @@
+package fr.nocsy.almpet.utils;
+
+import io.lumine.xikage.mythicmobs.MythicMobs;
+import io.lumine.xikage.mythicmobs.adapters.AbstractEntity;
+import io.lumine.xikage.mythicmobs.adapters.AbstractLocation;
+import io.lumine.xikage.mythicmobs.adapters.bukkit.BukkitAdapter;
+import net.minecraft.world.entity.EntityInsentient;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftLivingEntity;
+
+public class VolatileAIHandler {
+
+    public static boolean navigateToLocation(AbstractEntity entity, AbstractLocation destination)
+    {
+        String version = Bukkit.getServer().getMinecraftVersion();
+
+        if(version.equals("1.18"))
+        {
+            if (!entity.isLiving())
+                return false;
+
+            EntityInsentient e = (EntityInsentient) ((CraftLivingEntity) BukkitAdapter.adapt(entity)).getHandle();
+            e.D().a(destination.getX(), destination.getY(), destination.getZ(), 1.0D);
+        }
+        else
+        {
+            MythicMobs.inst().getVolatileCodeHandler().getAIHandler().navigateToLocation(entity, destination, Double.POSITIVE_INFINITY);
+        }
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
**FIX** - Naming both inventory (interaction & GUI) the same would cause the pet not to be revoked but respawned when clicking on the pet icon in the interaction menu
**TEMP** - Adding a security on pet multiplication spawn : pet may not be spawned again if it spawns too often (0.5s)
**ADD** - Making a versioning following system (1.17 & 1.18)
**ADD** - GivePet mechanic to give access to a pet using the mythicmobs